### PR TITLE
Dynamic SDL compiler and linker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SRC_DIR = src
 CC=g++
-CFLAGS= -Wall -g -std=c++11 -lSDL2 -lSDL2_image
-LDFLAGS=-lncurses
+CFLAGS= -Wall -g -std=c++11 $(shell sdl2-config --cflags)
+LDFLAGS=-lncurses $(shell sdl2-config --libs) -lSDL2_image
 SOURCES =$(wildcard $(SRC_DIR)/*.cpp)
 TARGET = rop
 OBJS = $(SOURCES:.cpp=.o)


### PR DESCRIPTION
The project didn't build for me due to undefined SDL functions.

Calling sdl2-config is the conventional way to set up SDL flags.